### PR TITLE
Max concurrency must be at least 1

### DIFF
--- a/lib/dns_cluster.ex
+++ b/lib/dns_cluster.ex
@@ -128,7 +128,7 @@ defmodule DNSCluster do
             log(state, "#{node()} connected to #{new_name}")
           end
         end,
-        max_concurrency: length(ips),
+        max_concurrency: max(1, length(ips)),
         timeout: timeout
       )
       |> Enum.to_list()


### PR DESCRIPTION
In production we encountered cases where there were no discovered ips, in this case the `Task.async_stream` crashed because `max_concurrency` was 0.