### PR TITLE
Support multiple DNS queries

### DIFF
--- a/lib/dns_cluster.ex
+++ b/lib/dns_cluster.ex
@@ -5,24 +5,20 @@ defmodule DNSCluster do
   A DNS query is made every `:interval` milliseconds to discover new ips.
 
   ## Default node discovery
-  When specifying a query, nodes will only be joined if their node basename matches
-  the basename of the current node. For example if `node()` is `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:1`,
-  a `Node.connect/1` attempt will be made against every IP returned by the DNS query,
-  but will only be successful if there is a node running on the remote host with the same
-  basename, for example `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:2`. Nodes running on
-  remote hosts, but with different basenames will fail to connect and will be ignored.
+  When you set up a DNS query, the system tries to connect to nodes with the same basename
+  as the local node. For example, if `node()` is `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:1`,
+  it will try to connect to every IP from the DNS query with `Node.connect/1`. But this will only
+  work if the remote node has the same basename, like `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:2`.
+  If the remote node's basename is different, the connection won't happen.
 
   ## Specifying remote basenames
-  To cluster nodes with differing basenames, specify `{basename, query}`. For example,
-  if the remote host has a node running with basename `remoteapp`, pass a tuple of
-  `{"remoteapp", "remote-app.internal"}`.
+  If you want to connect to nodes with different basenames, use a tuple with the basename and query.
+  For example, to connect to a node named `remote`, use `{"remote", "remote-app.internal"}`.
 
   ## Multiple queries
-  There are situations where you may want to cluster applications having differing
-  domain names. Simply pass a list of queries to connect to all Nodes, e.g.
-  `["app-one.internal", "app-two.internal", {"other-basename", "other.internal"}]`.
-  All rules for Node clustering still apply, so make sure that all Nodes share a
-  secret cookie, otherwise the nodes will fail to connect.
+  Sometimes you might want to cluster apps with different domain names. Just pass a list of queries
+  for this. For instance: `["app-one.internal", "app-two.internal", {"other-basename", "other.internal"}]`.
+  Remember, all nodes need to share the same secret cookie to connect successfully.
 
   ## Examples
 

--- a/lib/dns_cluster.ex
+++ b/lib/dns_cluster.ex
@@ -189,14 +189,15 @@ defmodule DNSCluster do
     |> Enum.map(fn {basename, addr} -> {basename, to_string(:inet.ntoa(addr))} end)
   end
 
-  defp valid_query?(string) when is_binary(string), do: true
-  defp valid_query?({basename, query}) when is_binary(basename) and is_binary(query), do: true
-
-  defp valid_query?(list) when is_list(list) do
-    Enum.all?(list, &valid_query?/1)
+  defp valid_query?(list) do
+    list
+    |> List.wrap()
+    |> Enum.all?(fn
+      string when is_binary(string) -> true
+      {basename, query} when is_binary(basename) and is_binary(query) -> true
+      _ -> false
+    end)
   end
-
-  defp valid_query?(_), do: false
 
   defp warn_on_invalid_dist do
     release? = is_binary(System.get_env("RELEASE_NAME"))

--- a/lib/dns_cluster.ex
+++ b/lib/dns_cluster.ex
@@ -5,11 +5,11 @@ defmodule DNSCluster do
   A DNS query is made every `:interval` milliseconds to discover new ips.
 
   ## Default node discovery
-  When you set up a DNS query, the system tries to connect to nodes with the same basename
-  as the local node. For example, if `node()` is `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:1`,
-  it will try to connect to every IP from the DNS query with `Node.connect/1`. But this will only
-  work if the remote node has the same basename, like `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:2`.
-  If the remote node's basename is different, the connection won't happen.
+  Nodes will only be joined if their node basename matches the basename of the current node.
+  For example, if `node()` is `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:1`, it will try to connect
+  to every IP from the DNS query with `Node.connect/1`. But this will only work if the remote node
+  has the same basename, like `myapp-123@fdaa:1:36c9:a7b:198:c4b1:73c6:2`. If the remote node's
+  basename is different, the nodes will not connect.
 
   ## Specifying remote basenames
   If you want to connect to nodes with different basenames, use a tuple with the basename and query.

--- a/lib/dns_cluster.ex
+++ b/lib/dns_cluster.ex
@@ -57,7 +57,7 @@ defmodule DNSCluster do
 
     * `:name` - the name of the cluster. Defaults to `DNSCluster`.
     * `:query` - the required DNS query for node discovery, for example:
-      `"myapp.internal"` or `["bar.internal", "bar.internal"]`.
+      `"myapp.internal"` or `["foo.internal", "bar.internal"]`.
       The value `:ignore` can be used to ignore starting the DNSCluster.
     * `:interval` - the millisec interval between DNS queries. Defaults to `5000`.
     * `:connect_timeout` - the millisec timeout to allow discovered nodes to connect.

--- a/test/dns_cluster_test.exs
+++ b/test/dns_cluster_test.exs
@@ -104,4 +104,39 @@ defmodule DNSClusterTest do
   test "query with :ignore does not start child" do
     assert DNSCluster.start_link(query: :ignore) == :ignore
   end
+
+  describe "query forms" do
+    test "query can be a string", config do
+      assert {:ok, _cluster} =
+               start_supervised(
+                 {DNSCluster, name: config.test, query: "app.internal", resolver: __MODULE__}
+               )
+    end
+
+    test "query can be a {basename, query}", config do
+      assert {:ok, _cluster} =
+               start_supervised(
+                 {DNSCluster,
+                  name: config.test, query: {"basename", "app.internal"}, resolver: __MODULE__}
+               )
+    end
+
+    test "query can be a list", config do
+      assert {:ok, _cluster} =
+               start_supervised(
+                 {DNSCluster,
+                  name: config.test,
+                  query: ["query", {"basename", "app.internal"}],
+                  resolver: __MODULE__}
+               )
+    end
+
+    test "query can't be other terms", config do
+      for bad <- [1234, :atom, %{a: 1}, [["query"]]] do
+        assert_raise RuntimeError, ~r/expected :query to be a string/, fn ->
+          start_supervised!({DNSCluster, name: config.test, query: bad, resolver: __MODULE__})
+        end
+      end
+    end
+  end
 end

--- a/test/dns_cluster_test.exs
+++ b/test/dns_cluster_test.exs
@@ -4,7 +4,8 @@ defmodule DNSClusterTest do
   @ips %{
     already_known: ~c"fdaa:0:36c9:a7b:db:400e:1352:1",
     new: ~c"fdaa:0:36c9:a7b:db:400e:1352:2",
-    no_connect_diff_base: ~c"fdaa:0:36c9:a7b:db:400e:1352:3"
+    no_connect_diff_base: ~c"fdaa:0:36c9:a7b:db:400e:1352:3",
+    connect_diff_base: ~c"fdaa:0:36c9:a7b:db:400e:1352:4"
   }
 
   @new_node :"app@#{@ips.new}"
@@ -18,14 +19,23 @@ defmodule DNSClusterTest do
     false
   end
 
+  @specified_base_node :"specified@#{@ips.connect_diff_base}"
+  def connect_node(@specified_base_node) do
+    send(__MODULE__, {:try_connect, @specified_base_node})
+    true
+  end
+
+  def connect_node(_), do: false
+
   def basename(_node_name), do: "app"
 
   def lookup(_query, _type) do
     {:ok, dns_ip1} = :inet.parse_address(@ips.already_known)
     {:ok, dns_ip2} = :inet.parse_address(@ips.new)
     {:ok, dns_ip3} = :inet.parse_address(@ips.no_connect_diff_base)
+    {:ok, dns_ip4} = :inet.parse_address(@ips.connect_diff_base)
 
-    [dns_ip1, dns_ip2, dns_ip3]
+    [dns_ip1, dns_ip2, dns_ip3, dns_ip4]
   end
 
   def list_nodes do
@@ -47,11 +57,30 @@ defmodule DNSClusterTest do
 
     wait_for_node_discovery(cluster)
 
-    {:ok, cluster: cluster}
     new_node = :"app@#{@ips.new}"
     no_connect_node = :"app@#{@ips.no_connect_diff_base}"
     assert_receive {:try_connect, ^new_node}
     refute_receive {:try_connect, ^no_connect_node}
+    refute_receive _
+  end
+
+  test "discovers nodes with differing basenames if specified", config do
+    Process.register(self(), __MODULE__)
+
+    {:ok, cluster} =
+      start_supervised(
+        {DNSCluster,
+         name: config.test,
+         query: ["app.internal", {"specified", "app.internal"}],
+         resolver: __MODULE__}
+      )
+
+    wait_for_node_discovery(cluster)
+
+    new_node = :"app@#{@ips.new}"
+    specified_base_node = :"specified@#{@ips.connect_diff_base}"
+    assert_receive {:try_connect, ^new_node}
+    assert_receive {:try_connect, ^specified_base_node}
     refute_receive _
   end
 
@@ -65,7 +94,6 @@ defmodule DNSClusterTest do
 
     wait_for_node_discovery(cluster)
 
-    {:ok, cluster: cluster}
     new_node = :"app@#{@ips.new}"
     no_connect_node = :"app@#{@ips.no_connect_diff_base}"
     assert_receive {:try_connect, ^new_node}


### PR DESCRIPTION
This PR extends the API to allow for a list of DNS queries. This is useful if you have multiple services that you want to cluster together