### PR TITLE
Some housekeeping

### DIFF
--- a/lib/dns_cluster/resolver.ex
+++ b/lib/dns_cluster/resolver.ex
@@ -1,0 +1,42 @@
+defmodule DNSCluster.Resolver do
+  @moduledoc false
+
+  require Record
+  Record.defrecord(:hostent, Record.extract(:hostent, from_lib: "kernel/include/inet.hrl"))
+
+  def basename(node_name) when is_atom(node_name) do
+    [basename, _] = String.split(to_string(node_name), "@")
+    basename
+  end
+
+  def connect_node(node_name) when is_atom(node_name), do: Node.connect(node_name)
+
+  def list_nodes, do: Node.list(:visible)
+
+  def lookup(query, type) when is_binary(query) and type in [:a, :aaaa] do
+    case :inet_res.getbyname(~c"#{query}", type) do
+      {:ok, hostent(h_addr_list: addr_list)} -> addr_list
+      {:error, _} -> []
+    end
+  end
+
+  def lookup(query, type) when is_binary(query) and type in [:srv] do
+    case :inet_res.getbyname(~c"#{query}", type) do
+      {:ok, hostent(h_addr_list: srv_list)} ->
+        lookup_hosts(srv_list)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp lookup_hosts(srv_list) do
+    srv_list
+    |> Enum.flat_map(fn {_prio, _weight, _port, host_name} ->
+      case :inet.gethostbyname(host_name) do
+        {:ok, hostent(h_addr_list: addr_list)} -> addr_list
+        {:error, _} -> []
+      end
+    end)
+  end
+end


### PR DESCRIPTION
While working on a solution for #14 I had the feeling the DNSCluster module is quite complex to read.

**Changes:**
* Moved `DNSCluster.Resolver` into its own file (`lib/dns_cluster/resolver.ex`)
* Replaced `valid_*?` with `validate_*!` functions to have less code in the `init/1` callback
* Get `:resource_types` from `opts` only when a `:query` is given
* ~Removed unused variable `_results` in the `connect_new_nodes/1` function~
* Replaced two nested `Enum.flat_map/2` with a for-loop