### PR TITLE
Add missing alias

### DIFF
--- a/lib/dns_cluster.ex
+++ b/lib/dns_cluster.ex
@@ -35,6 +35,9 @@ defmodule DNSCluster do
   [libcluster](https://hexdocs.pm/libcluster) library.
   """
   use GenServer
+
+  alias DNSCluster.Resolver
+
   require Logger
 
   @doc ~S"""


### PR DESCRIPTION
I forgot to add an alias for `DNSCluster.Resolver` when I moved the resolver module into its own file in #18 :disappointed: 

```elixir
iex> DNSCluster.start_link(query: "example.local")
** (EXIT from #PID<0.216.0>) shell process exited with reason: an exception was raised:                   
    ** (UndefinedFunctionError) function Resolver.basename/1 is undefined (module Resolver is not available). Make sure the module name is correct and has been specified in full (or that an alias has been defined)
        Resolver.basename(:nonode@nohost)            
        (dns_cluster 0.2.0) lib/dns_cluster.ex:88: DNSCluster.init/1                                      
        (stdlib 6.2.1) gen_server.erl:2229: :gen_server.init_it/2                                         
        (stdlib 6.2.1) gen_server.erl:2184: :gen_server.init_it/6
        (stdlib 6.2.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

I only ran the tests to see if everything is still working, but the tests are always using a custom resolver.