### PR TITLE
Add support for connecting to nodes by their hostname

### DIFF
--- a/test/dns_cluster_test.exs
+++ b/test/dns_cluster_test.exs
@@ -141,7 +141,8 @@ defmodule DNSClusterTest do
   end
 
   describe "resource_types" do
-    test "resource_types can be a subset of [:a, :aaaa, :srv]", config do
+    test "resource_types can be a subset of [:a, :aaaa, :srv, {:srv, :ips}, {:srv, :hostnames}]",
+         config do
       assert {:ok, _cluster} =
                start_supervised(
                  {DNSCluster,
@@ -152,9 +153,10 @@ defmodule DNSClusterTest do
                )
     end
 
-    test "resource_types can't be outside of [:a, :aaaa, :srv]", config do
+    test "resource_types can't be outside of [:a, :aaaa, :srv, {:srv, :ips}, {:srv, :hostnames}]",
+         config do
       assert_raise RuntimeError,
-                   ~r/expected :resource_types to be a subset of \[:a, :aaaa, :srv\]/,
+                   ~r/expected :resource_types to be a subset of \[:a, :aaaa, :srv, {:srv, :ips}, {:srv, :hostnames}\]/,
                    fn ->
                      start_supervised!(
                        {DNSCluster,
@@ -168,7 +170,7 @@ defmodule DNSClusterTest do
 
     test "resource_types can't be empty", config do
       assert_raise RuntimeError,
-                   ~r/expected :resource_types to be a subset of \[:a, :aaaa, :srv\]/,
+                   ~r/expected :resource_types to be a subset of \[:a, :aaaa, :srv, {:srv, :ips}, {:srv, :hostnames}\]/,
                    fn ->
                      start_supervised!(
                        {DNSCluster,


### PR DESCRIPTION
This PR adds a new option `address_type` which can be `:ip` (default) or `:hostname` to control whether to connect to other nodes via their ip address or hostname.

The resolver `lookup` function changed from 2-arity to 3-arity, because we now also need to pass the new `address_type` to it.

To not break backwards compatibility for users with custom resolver implementations (e.g. custom dns servers, DB lookup), the implementation calls `lookup/3` if available, calls `lookup/3` when `address_type == :hostname` and otherwise falls back to `lookup/2`.

### Setup

```console
$ dig A app.dev.acme.com +short
192.168.100.1

$ dig AAAA app.dev.acme.com +short
::ffff:192.168.100.1

$ dig SRV app.dev.acme.com +short
1 10 4000 app-1.dev.acme.com
1 10 4000 app-2.dev.acme.com
1 10 4000 app-3.dev.acme.com

$ dig A app-1.dev.acme.com +short
192.168.100.101

$ dig A app-2.dev.acme.com +short
192.168.100.102

$ dig A app-3.dev.acme.com +short
192.168.100.103
```

### Resolving

```elixir
iex> DNSCluster.Resolver.lookup("app.dev.acme.com", :a)
[{192, 168, 100, 1}]

iex> DNSCluster.Resolver.lookup("app.dev.acme.com", :aaaa)
[{0,0,0,0,0,65535,49320,25601}]

iex> DNSCluster.Resolver.lookup("app.dev.acme.com", :srv)
[{192, 168, 100, 101}, {192, 168, 100, 102}, {192, 168, 100, 103}]

iex> DNSCluster.Resolver.lookup("app.dev.acme.com", {:srv, :ips})
[{192, 168, 100, 101}, {192, 168, 100, 102}, {192, 168, 100, 103}]

iex> DNSCluster.Resolver.lookup("app.dev.acme.com", {:srv, :hostnames})
[~c"app-1.dev.acme.com", ~c"app-2.dev.acme.com", ~c"app-3.dev.acme.com"]
```

### TODOs

* [ ] Add tests
* [ ] Update documentation

Fixes #14